### PR TITLE
Use XRT native C++ API with cxx

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,8 @@
+[submodule "fpga-xrt/util-linux"]
+	path = fpga-xrt/util-linux
+	url = https://github.com/karelzak/util-linux.git
+	branch = stable/v2.37
+[submodule "fpga-xrt/xrt"]
+	path = fpga-xrt/xrt
+	url = https://github.com/xilinx/xrt.git
+	branch = master

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# fpga-rs
+
+## Minimum supported Rust version
+
+The minimum supported Rust version is 1.56.

--- a/fpga-core/src/lib.rs
+++ b/fpga-core/src/lib.rs
@@ -1,14 +1,67 @@
-use std::error::Error;
+use std::{
+    error::Error,
+    fmt::{self, Display, Formatter},
+};
+
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PlatformType {
+    XRT,
+    OPAE,
+}
+
+impl Display for PlatformType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::XRT => "xrt",
+                Self::OPAE => "opae",
+            }
+        )
+    }
+}
 
 pub trait Platform: Sized {
-    const NAME: &'static str;
-
     /// Platform specific configuration. Required to construct this platform.
     type Configuration;
 
     /// Platform specific error type.
     type Error: Error;
 
+    /// Returns specific [PlatformType]. Can be used when performing platform
+    /// tasks e.g. selecting a bit stream compatible with this platform. Can
+    /// also be used to downcast a trait object to a concrete type.
+    fn platform(&self) -> PlatformType;
+
     /// Constructs and initializes this platform using the provided platform configuration.
     fn from_configuration(configuration: Self::Configuration) -> Result<Self, Self::Error>;
+}
+
+pub trait MMIO: Platform {
+    fn read_mmio<const N: usize>(&self, offset: usize, len: usize) -> Result<[u8; N], Self::Error>;
+    fn write_mmio<T>(&mut self, offset: usize, data: T) -> Result<(), Self::Error>
+    where
+        T: AsRef<[u8]>;
+}
+
+pub trait Power: Platform {
+    /// Current power usage in Watts.
+    fn power(&self) -> f32;
+}
+
+pub trait Thermal: Platform {
+    /// Current temperature of device in degrees C.
+    fn temperature(&self) -> f32;
+    /// Current temperature of device in degrees F.
+    fn temperature_f(&self) -> f32 {
+        (self.temperature() * 9. / 5.) + 32.
+    }
+}
+
+pub trait Program: Platform {
+    type Source;
+    type Output;
+    fn program(&mut self, source: Self::Source) -> Result<Self::Output, Self::Error>;
 }

--- a/fpga-xrt/Cargo.toml
+++ b/fpga-xrt/Cargo.toml
@@ -1,17 +1,15 @@
 [package]
 name = "fpga-xrt"
 version = "0.1.0"
-authors = ["Matthijs Brobbel <m1brobbel@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-fpga-core = { path = "../fpga-core" }
-libc = "0.2"
-log = "0.4"
+cxx = "1"
 uuid = "0.8"
 
 [build-dependencies]
-bindgen = "0.58"
-flate2 = "1.0"
-reqwest = { version = "0.11", features = ["blocking"] }
-tar = "0.4"
+bindgen = "0.59"
+cc = "1"
+cmake = "0.1"
+cxx-build = "1"
+glob = "0.3"

--- a/fpga-xrt/Cargo.toml
+++ b/fpga-xrt/Cargo.toml
@@ -3,12 +3,17 @@ name = "fpga-xrt"
 version = "0.1.0"
 edition = "2018"
 
+[features]
+default = []
+
 [dependencies]
 cxx = "1"
-uuid = "0.8"
+fpga-core = { path = "../fpga-core" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+uuid = { version = "0.8", features = ["serde"] }
 
 [build-dependencies]
-bindgen = "0.59"
 cc = "1"
 cmake = "0.1"
 cxx-build = "1"

--- a/fpga-xrt/build.rs
+++ b/fpga-xrt/build.rs
@@ -2,6 +2,8 @@ use cc::Build;
 use glob::glob;
 use std::{env, error::Error, ffi::OsStr, path::PathBuf, process::Command};
 
+// xrt 202020.2.8.743
+
 fn uuid_static() -> Result<(), Box<dyn Error>> {
     // Build and link static uuid.
     glob("util-linux/libuuid/src/*.c")?

--- a/fpga-xrt/build.rs
+++ b/fpga-xrt/build.rs
@@ -88,6 +88,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
     cxx_build::bridge("src/ffi.rs")
         .include(manifest_dir.join("xrt/src/runtime_src/core/include"))
+        // todo(mb): remove
+        .include(manifest_dir.join("xrt/src/runtime_src/"))
         .include(env::var("OUT_DIR")?)
         .include(manifest_dir)
         .file("src/ffi.cc")

--- a/fpga-xrt/build.rs
+++ b/fpga-xrt/build.rs
@@ -1,54 +1,129 @@
-use flate2::read::GzDecoder;
-use std::{env, path::PathBuf};
-use tar::Archive;
+use cc::Build;
+use glob::glob;
+use std::{env, error::Error, ffi::OsStr, path::PathBuf, process::Command};
 
-const XRT_VERSION: &str = "b7f8b62eecdba9caf906893cd22aa5dd39795766";
-const XRT_REPOSITORY: &str = "https://github.com/Xilinx/XRT";
+fn uuid_static() -> Result<(), Box<dyn Error>> {
+    // Build and link static uuid.
+    glob("util-linux/libuuid/src/*.c")?
+        .map(Result::unwrap)
+        .filter(|path| path.is_file())
+        .filter(|path| {
+            let file_name = path.file_name().unwrap();
+            // Skip test file.
+            file_name != OsStr::new("test_uuid.c") &&
+            // This file produces some warnings when build without autoconf.
+            // Skip because we don't need symbols from it.
+            file_name != OsStr::new("gen_uuid.c")
+        })
+        .fold(Build::new(), |mut build, path| {
+            build.file(path);
+            build
+        })
+        // At least one method must be available so we pick nanosleep.
+        .define("HAVE_NANOSLEEP", None)
+        .file("util-linux/lib/randutils.c")
+        .file("util-linux/lib/md5.c")
+        .file("util-linux/lib/sha1.c")
+        .include("util-linux/libuuid")
+        .include("util-linux/include")
+        .compile("uuid");
 
-fn main() {
-    println!("cargo:rustc-link-lib=xrt_core");
-    println!("cargo:rustc-link-lib=xrt_coreutil");
+    Ok(())
+}
 
-    let xrt_download_url = format!("{}/archive/{}.tar.gz", XRT_REPOSITORY, XRT_VERSION);
-    let xrt_dir = format!("XRT-{}", XRT_VERSION);
+fn boost_static() -> Result<(), Box<dyn Error>> {
+    // Build and link static boost, using the script provided by XRT.
+    // Static libs are installed in OUT_DIR/boost/xrt/lib.
+    Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            "xrt/src/runtime_src/tools/scripts/boost.sh -prefix {}/boost",
+            env::var("OUT_DIR")?
+        ))
+        .spawn()?
+        .wait_with_output()?;
 
-    // Setup output directory
-    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    if !out_dir.join(&xrt_dir).exists() {
-        // Download xrt
-        let download = reqwest::blocking::get(&xrt_download_url).expect("xrt download failed");
-        // Extract to output directory
-        Archive::new(GzDecoder::new(download))
-            .unpack(&out_dir)
-            .expect("xrt tarball extract failed");
-    }
+    // Add path of static boost libs to linker search.
+    println!(
+        "cargo:rustc-link-search=native={}/boost/xrt/lib",
+        env::var("OUT_DIR")?
+    );
 
-    let include_dir = out_dir.join(&xrt_dir).join("src/runtime_src/core/include");
-    let include_dir = include_dir.display();
+    // Set boot env for xrt build.
+    env::set_var("XRT_BOOST_INSTALL", format!("{}/boost/xrt", env::var("OUT_DIR")?));
 
-    bindgen::Builder::default()
-        .header(format!("{}/xrt.h", include_dir))
-        .header(format!("{}/xrt/xrt_bo.h", include_dir))
-        .header(format!("{}/xrt/xrt_device.h", include_dir))
-        .header(format!("{}/xrt/xrt_kernel.h", include_dir))
-        .header(format!("{}/xrt/xrt_uuid.h", include_dir))
-        .header(format!("{}/experimental/xrt_ini.h", include_dir))
-        .header(format!("{}/experimental/xrt_error.h", include_dir))
-        .header(format!("{}/xrt_error_code.h", include_dir))
-        .clang_arg(format!("-I{}", include_dir))
-        .allowlist_function("xrt.*")
-        .allowlist_type("xrt.*")
-        .allowlist_var("xrt.*")
-        .allowlist_function("xcl.*")
-        .allowlist_type("xcl.*")
-        .allowlist_var("xcl.*")
-        .rustified_enum(".*")
-        .derive_debug(true)
-        .derive_default(true)
-        .impl_debug(true)
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
-        .generate()
-        .expect("failed to generate bindings")
-        .write_to_file(out_dir.join("bindings.rs"))
-        .expect("failed to write bindings");
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    uuid_static()?;
+    boost_static()?;
+
+    let xrt_coreutil_static = cmake::Config::new("xrt/src")
+        .env("XRT_BOOST_INSTALL", format!("{}/boost/xrt", env::var("OUT_DIR")?))
+        .build_target("xrt_coreutil_static")
+        .build();
+
+    println!("cargo:rustc-link-search=native={}/build/runtime_src/core/common", xrt_coreutil_static.display());
+
+    let xrt_core_static = cmake::Config::new("xrt/src")
+        .env("XRT_BOOST_INSTALL", format!("{}/boost/xrt", env::var("OUT_DIR")?))
+        .build_target("xrt_core_static")
+        .build();
+
+    println!("cargo:rustc-link-search=native={}/build/runtime_src/core/pcie/linux", xrt_core_static.display());
+
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
+    cxx_build::bridge("src/ffi.rs")
+        .include(manifest_dir.join("xrt/src/runtime_src/core/include"))
+        .include(env::var("OUT_DIR")?)
+        .include(manifest_dir)
+        .file("src/ffi.cc")
+        .flag("-std=gnu++14")
+        .compile("fpga-xrt");
+
+    println!("cargo:rerun-if-changed=src/ffi.rs");
+    println!("cargo:rerun-if-changed=src/ffi.h");
+    println!("cargo:rerun-if-changed=src/ffi.cc");
+
+    // Link to xrt_core_static.
+    println!("cargo:rustc-link-arg=-Wl,--whole-archive");
+    println!("cargo:rustc-link-arg=-lxrt_core_static");
+    println!("cargo:rustc-link-arg=-Wl,--no-whole-archive");
+    
+    println!("cargo:rustc-link-lib=static=xrt_coreutil_static");
+    
+    println!("cargo:rustc-link-arg=-Wl,--whole-archive");
+    println!("cargo:rustc-link-arg=-lrt");
+    println!("cargo:rustc-link-arg=-lpthread");
+    println!("cargo:rustc-link-arg=-Wl,--no-whole-archive");
+
+    // First link to static boost libs.
+    println!("cargo:rustc-link-lib=static=boost_filesystem");
+    println!("cargo:rustc-link-lib=static=boost_system");
+
+    println!("cargo:rustc-link-arg=-lc");
+    println!("cargo:rustc-link-arg=-lstdc++");
+
+    // // Generate some bindings
+    // bindgen::Builder::default()
+    //     .header("xrt/src/runtime_src/core/include/xrt/xrt_uuid.h")
+    //     .clang_arg("-Ixrt/src/runtime_src/core/include/")
+    //     .allowlist_function("xrt.*")
+    //     .allowlist_type("xrt.*")
+    //     .allowlist_var("xrt.*")
+    //     .allowlist_function("xcl.*")
+    //     .allowlist_type("xcl.*")
+    //     .allowlist_var("xcl.*")
+    //     .rustified_enum(".*")
+    //     .derive_debug(true)
+    //     .derive_default(true)
+    //     .impl_debug(true)
+    //     .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+    //     .generate()
+    //     .expect("failed to generate bindings")
+    //     .write_to_file(format!("{}/bindings.rs", env::var("OUT_DIR")?))
+    //     .expect("failed to write bindings");
+
+    Ok(())
 }

--- a/fpga-xrt/src/bindings.rs
+++ b/fpga-xrt/src/bindings.rs
@@ -1,6 +1,0 @@
-#![allow(non_camel_case_types)]
-#![allow(dead_code)]
-#![allow(broken_intra_doc_links)]
-#![allow(non_snake_case)]
-#![allow(deref_nullptr)]
-include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/fpga-xrt/src/ffi.cc
+++ b/fpga-xrt/src/ffi.cc
@@ -1,0 +1,25 @@
+#include "src/ffi.h"
+// #include "fpga-xrt/src/ffi.rs.h"
+#include "xrt/xrt_device.h"
+
+namespace xrt {
+
+rust::String Device::name() const {
+  return get_info<xrt::info::device::name>();
+}
+
+rust::String Device::bdf() const {
+  return get_info<xrt::info::device::bdf>();
+}
+
+std::array<unsigned char, 16> Device::xclbin_uuid() const {
+  std::array<unsigned char, 16> array;
+  memcpy(array.data(), get_xclbin_uuid().get(), sizeof(unsigned char) * 16);
+  return array;
+}
+
+std::unique_ptr<Device> new_device(unsigned int index) {
+  return std::make_unique<Device>(index);
+}
+
+}

--- a/fpga-xrt/src/ffi.cc
+++ b/fpga-xrt/src/ffi.cc
@@ -1,20 +1,44 @@
 #include "src/ffi.h"
 // #include "fpga-xrt/src/ffi.rs.h"
 
-// todo(mb): remove
 #include <iostream>
 
 // Xclbin
 namespace xrt
 {
-  rust::String xclbin_kernel_get_name(const xclbin_kernel &kernel)
+  rust::Str XclbinArg::name() const
   {
-    return kernel.get_name();
+    return get_name();
   }
 
-  rust::String xclbin_ip_get_name(const xclbin_ip &ip)
+  std::unique_ptr<std::vector<XclbinMem>> XclbinArg::mems() const
   {
-    return ip.get_name();
+    std::vector<xclbin::mem> input = get_mems();
+    std::vector<XclbinMem> output(input.begin(), input.end());
+    return std::make_unique<std::vector<XclbinMem>>(output);
+  }
+
+  rust::Str XclbinKernel::name() const
+  {
+    return get_name();
+  }
+
+  rust::Str XclbinIp::name() const
+  {
+    return get_name();
+  }
+
+  std::unique_ptr<std::vector<XclbinArg>> XclbinIp::args() const
+  {
+    std::vector<xclbin::arg> input = get_args();
+    std::vector<XclbinArg> output(input.begin(), input.end());
+    return std::make_unique<std::vector<XclbinArg>>(output);
+  }
+
+  std::unique_ptr<XclbinArg> XclbinIp::arg(int32_t index) const
+  {
+    xclbin::arg arg = get_arg(index);
+    return std::make_unique<XclbinArg>(arg);
   }
 
   std::unique_ptr<Xclbin> new_xclbin(const rust::Slice<const int8_t> data)
@@ -23,27 +47,42 @@ namespace xrt
     return std::make_unique<Xclbin>(input);
   }
 
-  std::unique_ptr<std::vector<xclbin::kernel>> Xclbin::get_kernels() const
+  std::unique_ptr<std::vector<XclbinKernel>> Xclbin::kernels() const
   {
-    return std::make_unique<std::vector<xclbin::kernel>>(xclbin::get_kernels());
+    std::vector<xclbin::kernel> input = get_kernels();
+    std::vector<XclbinKernel> output(input.begin(), input.end());
+    return std::make_unique<std::vector<XclbinKernel>>(output);
   }
 
-  std::unique_ptr<std::vector<xclbin::ip>> Xclbin::get_ips() const
+  std::unique_ptr<XclbinKernel> Xclbin::kernel(const rust::Str name) const
   {
-    return std::make_unique<std::vector<xclbin::ip>>(xclbin::get_ips());
+    return std::make_unique<XclbinKernel>(get_kernel(std::string(name)));
   }
 
-  rust::String Xclbin::get_xsa_name() const
+  std::unique_ptr<std::vector<XclbinIp>> Xclbin::ips() const
   {
-    return xclbin::get_xsa_name();
+    std::vector<xclbin::ip> input = get_ips();
+    std::vector<XclbinIp> output(input.begin(), input.end());
+    return std::make_unique<std::vector<XclbinIp>>(output);
   }
 
-  std::array<unsigned char, 16> Xclbin::get_uuid() const
+  std::unique_ptr<XclbinIp> Xclbin::ip(const rust::Str name) const
+  {
+    return std::make_unique<XclbinIp>(get_ip(std::string(name)));
+  }
+
+  rust::Str Xclbin::xsa_name() const
+  {
+    return get_xsa_name();
+  }
+
+  std::array<unsigned char, 16> Xclbin::uuid() const
   {
     std::array<unsigned char, 16> array;
     memcpy(array.data(), xclbin::get_uuid().get(), sizeof(unsigned char) * 16);
     return array;
   }
+
 }
 
 // Device
@@ -54,7 +93,12 @@ namespace xrt
     return std::make_unique<Device>(index);
   }
 
-  rust::String Device::bdf() const
+  std::unique_ptr<Device> new_device_bdf(const rust::Str bdf)
+  {
+    return std::make_unique<Device>(std::string(bdf));
+  }
+
+  rust::Str Device::bdf() const
   {
     return get_info<xrt::info::device::bdf>();
   }
@@ -81,7 +125,7 @@ namespace xrt
     return get_info<xrt::info::device::m2m>();
   }
 
-  rust::String Device::name() const
+  rust::Str Device::name() const
   {
     return get_info<xrt::info::device::name>();
   }
@@ -96,45 +140,45 @@ namespace xrt
     return get_info<xrt::info::device::offline>();
   }
 
-  rust::String Device::electrical() const
-  {
-    return get_info<xrt::info::device::electrical>();
-  }
+  // rust::String Device::electrical() const
+  // {
+  //   return get_info<xrt::info::device::electrical>();
+  // }
 
-  rust::String Device::thermal() const
-  {
-    return get_info<xrt::info::device::thermal>();
-  }
+  // rust::String Device::thermal() const
+  // {
+  //   return get_info<xrt::info::device::thermal>();
+  // }
 
-  rust::String Device::mechanical() const
-  {
-    return get_info<xrt::info::device::mechanical>();
-  }
+  // rust::String Device::mechanical() const
+  // {
+  //   return get_info<xrt::info::device::mechanical>();
+  // }
 
-  rust::String Device::memory() const
-  {
-    return get_info<xrt::info::device::memory>();
-  }
+  // rust::String Device::memory() const
+  // {
+  //   return get_info<xrt::info::device::memory>();
+  // }
 
-  rust::String Device::platform() const
-  {
-    return get_info<xrt::info::device::platform>();
-  }
+  // rust::String Device::platform() const
+  // {
+  //   return get_info<xrt::info::device::platform>();
+  // }
 
-  rust::String Device::pcie_info() const
-  {
-    return get_info<xrt::info::device::pcie_info>();
-  }
+  // rust::String Device::pcie_info() const
+  // {
+  //   return get_info<xrt::info::device::pcie_info>();
+  // }
 
-  rust::String Device::host() const
-  {
-    return get_info<xrt::info::device::host>();
-  }
+  // rust::String Device::host() const
+  // {
+  //   return get_info<xrt::info::device::host>();
+  // }
 
-  rust::String Device::dynamic_regions() const
-  {
-    return get_info<xrt::info::device::dynamic_regions>();
-  }
+  // rust::String Device::dynamic_regions() const
+  // {
+  //   return get_info<xrt::info::device::dynamic_regions>();
+  // }
 
   std::array<unsigned char, 16> Device::xclbin_uuid() const
   {
@@ -143,13 +187,10 @@ namespace xrt
     return array;
   }
 
-  std::array<unsigned char, 16> Device::load_xclbin(const Xclbin &xclbin)
+  std::array<unsigned char, 16> Device::load(const Xclbin &xclbin)
   {
+    auto uuid = load_xclbin(xclbin).get();
     std::array<unsigned char, 16> array;
-    std::cout << "load_xclbin" << std::endl;
-    xrt::xclbin input = xclbin;
-    auto uuid = xrt::device::load_xclbin(input).get();
-    std::cout << "load_xclbin done" << std::endl;
     memcpy(array.data(), uuid, sizeof(unsigned char) * 16);
     return array;
   }
@@ -160,14 +201,35 @@ namespace xrt
 {
   std::unique_ptr<kernel> new_kernel(const Device &device,
                                      std::array<unsigned char, 16> xclbin_id,
-                                     const rust::String name,
+                                     const rust::Str name,
                                      kernel_cu_access_mode mode)
   {
-    unsigned char uuid[16];
-    memcpy(uuid, xclbin_id.data(), sizeof(unsigned char) * 16);
-    xrt::uuid xclbin_id_(uuid);
-    std::string name_(name);
-    xrt::device device_(device);
-    return std::make_unique<kernel>(device_, xclbin_id_, name_, mode);
+    xrt::uuid uuid(xclbin_id.data());
+    // // workaround that registers the alxf
+    // std::shared_ptr<xrt_core::device> handle = device.get_handle();
+    // handle->register_axlf(xclbin.get_axlf());
+    // xrt::xclbin bin(xclbin);
+    return std::make_unique<kernel>(device, uuid, std::string(name), mode);
+  }
+}
+
+// IP
+namespace xrt
+{
+  std::unique_ptr<ip> new_ip(const Device &device,
+                             std::array<unsigned char, 16> xclbin_id,
+                             const rust::Str name)
+  {
+    xrt::uuid uuid(xclbin_id.data());
+    return std::make_unique<ip>(device, uuid, std::string(name));
+  }
+}
+
+// Ini
+namespace xrt
+{
+  void set_ini(rust::Str key, rust::Str value)
+  {
+    xrt::ini::set(std::string(key), std::string(value));
   }
 }

--- a/fpga-xrt/src/ffi.cc
+++ b/fpga-xrt/src/ffi.cc
@@ -1,6 +1,9 @@
 #include "src/ffi.h"
 // #include "fpga-xrt/src/ffi.rs.h"
 
+// todo(mb): remove
+#include <iostream>
+
 // Xclbin
 namespace xrt
 {
@@ -143,9 +146,11 @@ namespace xrt
   std::array<unsigned char, 16> Device::load_xclbin(const Xclbin &xclbin)
   {
     std::array<unsigned char, 16> array;
+    std::cout << "load_xclbin" << std::endl;
     xrt::xclbin input = xclbin;
-    xrt::uuid uuid = device::load_xclbin(input);
-    memcpy(array.data(), uuid.get(), sizeof(unsigned char) * 16);
+    auto uuid = xrt::device::load_xclbin(input).get();
+    std::cout << "load_xclbin done" << std::endl;
+    memcpy(array.data(), uuid, sizeof(unsigned char) * 16);
     return array;
   }
 }

--- a/fpga-xrt/src/ffi.cc
+++ b/fpga-xrt/src/ffi.cc
@@ -1,25 +1,168 @@
 #include "src/ffi.h"
 // #include "fpga-xrt/src/ffi.rs.h"
-#include "xrt/xrt_device.h"
 
-namespace xrt {
+// Xclbin
+namespace xrt
+{
+  rust::String xclbin_kernel_get_name(const xclbin_kernel &kernel)
+  {
+    return kernel.get_name();
+  }
 
-rust::String Device::name() const {
-  return get_info<xrt::info::device::name>();
+  rust::String xclbin_ip_get_name(const xclbin_ip &ip)
+  {
+    return ip.get_name();
+  }
+
+  std::unique_ptr<Xclbin> new_xclbin(const rust::Slice<const int8_t> data)
+  {
+    std::vector<char> input(data.begin(), data.end());
+    return std::make_unique<Xclbin>(input);
+  }
+
+  std::unique_ptr<std::vector<xclbin::kernel>> Xclbin::get_kernels() const
+  {
+    return std::make_unique<std::vector<xclbin::kernel>>(xclbin::get_kernels());
+  }
+
+  std::unique_ptr<std::vector<xclbin::ip>> Xclbin::get_ips() const
+  {
+    return std::make_unique<std::vector<xclbin::ip>>(xclbin::get_ips());
+  }
+
+  rust::String Xclbin::get_xsa_name() const
+  {
+    return xclbin::get_xsa_name();
+  }
+
+  std::array<unsigned char, 16> Xclbin::get_uuid() const
+  {
+    std::array<unsigned char, 16> array;
+    memcpy(array.data(), xclbin::get_uuid().get(), sizeof(unsigned char) * 16);
+    return array;
+  }
 }
 
-rust::String Device::bdf() const {
-  return get_info<xrt::info::device::bdf>();
+// Device
+namespace xrt
+{
+  std::unique_ptr<Device> new_device(unsigned int index)
+  {
+    return std::make_unique<Device>(index);
+  }
+
+  rust::String Device::bdf() const
+  {
+    return get_info<xrt::info::device::bdf>();
+  }
+
+  std::array<unsigned char, 16> Device::interface_uuid() const
+  {
+    std::array<unsigned char, 16> array;
+    memcpy(array.data(), get_info<xrt::info::device::interface_uuid>().get(), sizeof(unsigned char) * 16);
+    return array;
+  }
+
+  uint32_t Device::kdma() const
+  {
+    return get_info<xrt::info::device::kdma>();
+  }
+
+  unsigned long Device::max_clock_frequency_mhz() const
+  {
+    return get_info<xrt::info::device::max_clock_frequency_mhz>();
+  }
+
+  bool Device::m2m() const
+  {
+    return get_info<xrt::info::device::m2m>();
+  }
+
+  rust::String Device::name() const
+  {
+    return get_info<xrt::info::device::name>();
+  }
+
+  bool Device::nodma() const
+  {
+    return get_info<xrt::info::device::nodma>();
+  }
+
+  bool Device::offline() const
+  {
+    return get_info<xrt::info::device::offline>();
+  }
+
+  rust::String Device::electrical() const
+  {
+    return get_info<xrt::info::device::electrical>();
+  }
+
+  rust::String Device::thermal() const
+  {
+    return get_info<xrt::info::device::thermal>();
+  }
+
+  rust::String Device::mechanical() const
+  {
+    return get_info<xrt::info::device::mechanical>();
+  }
+
+  rust::String Device::memory() const
+  {
+    return get_info<xrt::info::device::memory>();
+  }
+
+  rust::String Device::platform() const
+  {
+    return get_info<xrt::info::device::platform>();
+  }
+
+  rust::String Device::pcie_info() const
+  {
+    return get_info<xrt::info::device::pcie_info>();
+  }
+
+  rust::String Device::host() const
+  {
+    return get_info<xrt::info::device::host>();
+  }
+
+  rust::String Device::dynamic_regions() const
+  {
+    return get_info<xrt::info::device::dynamic_regions>();
+  }
+
+  std::array<unsigned char, 16> Device::xclbin_uuid() const
+  {
+    std::array<unsigned char, 16> array;
+    memcpy(array.data(), get_xclbin_uuid().get(), sizeof(unsigned char) * 16);
+    return array;
+  }
+
+  std::array<unsigned char, 16> Device::load_xclbin(const Xclbin &xclbin)
+  {
+    std::array<unsigned char, 16> array;
+    xrt::xclbin input = xclbin;
+    xrt::uuid uuid = device::load_xclbin(input);
+    memcpy(array.data(), uuid.get(), sizeof(unsigned char) * 16);
+    return array;
+  }
 }
 
-std::array<unsigned char, 16> Device::xclbin_uuid() const {
-  std::array<unsigned char, 16> array;
-  memcpy(array.data(), get_xclbin_uuid().get(), sizeof(unsigned char) * 16);
-  return array;
-}
-
-std::unique_ptr<Device> new_device(unsigned int index) {
-  return std::make_unique<Device>(index);
-}
-
+// Kernel
+namespace xrt
+{
+  std::unique_ptr<kernel> new_kernel(const Device &device,
+                                     std::array<unsigned char, 16> xclbin_id,
+                                     const rust::String name,
+                                     kernel_cu_access_mode mode)
+  {
+    unsigned char uuid[16];
+    memcpy(uuid, xclbin_id.data(), sizeof(unsigned char) * 16);
+    xrt::uuid xclbin_id_(uuid);
+    std::string name_(name);
+    xrt::device device_(device);
+    return std::make_unique<kernel>(device_, xclbin_id_, name_, mode);
+  }
 }

--- a/fpga-xrt/src/ffi.h
+++ b/fpga-xrt/src/ffi.h
@@ -1,41 +1,66 @@
 #pragma once
 #include "rust/cxx.h"
 
-#include "fpga-xrt/xrt/src/runtime_src/core/include/experimental/xrt_device.h"
-#include "fpga-xrt/xrt/src/runtime_src/core/include/experimental/xrt_kernel.h"
+#include "fpga-xrt/xrt/src/runtime_src/core/include/xrt/xrt_device.h"
+#include "fpga-xrt/xrt/src/runtime_src/core/include/xrt/xrt_kernel.h"
 
-// #include "fpga-xrt/xrt/src/runtime_src/core/include/xrt/xrt_device.h"
-// #include "fpga-xrt/xrt/src/runtime_src/core/include/xrt/xrt_kernel.h"
-
+#include "fpga-xrt/xrt/src/runtime_src/core/include/experimental/xrt_ini.h"
+#include "fpga-xrt/xrt/src/runtime_src/core/include/experimental/xrt_ip.h"
 #include "fpga-xrt/xrt/src/runtime_src/core/include/experimental/xrt_xclbin.h"
-
-// #include <memory>
 
 namespace xrt
 {
-  // export nested class.
-  using xclbin_kernel = xclbin::kernel;
+  class XclbinMem : public xclbin::mem
+  {
+    using xclbin::mem::mem;
 
-  rust::String xclbin_kernel_get_name(const xclbin_kernel &kernel);
+  public:
+    XclbinMem(const xclbin::mem &mem) : xclbin::mem(mem){};
+  };
 
-  // export nested class.
-  using xclbin_ip = xclbin::ip;
+  class XclbinArg : public xclbin::arg
+  {
+    using xclbin::arg::arg;
 
-  rust::String xclbin_ip_get_name(const xclbin_ip &ip);
+  public:
+    XclbinArg(const xclbin::arg &arg) : xclbin::arg(arg){};
+    rust::Str name() const;
+    std::unique_ptr<std::vector<XclbinMem>> mems() const;
+  };
+
+  class XclbinKernel : public xclbin::kernel
+  {
+    using xclbin::kernel::kernel;
+
+  public:
+    XclbinKernel(const xclbin::kernel &kernel) : xclbin::kernel(kernel){};
+    rust::Str name() const;
+  };
+
+  class XclbinIp : public xclbin::ip
+  {
+    using xclbin::ip::ip;
+
+  public:
+    XclbinIp(const xclbin::ip &ip) : xclbin::ip(ip){};
+    rust::Str name() const;
+    std::unique_ptr<std::vector<XclbinArg>> args() const;
+    std::unique_ptr<XclbinArg> arg(int32_t index) const;
+  };
 
   class Xclbin : public xrt::xclbin
   {
-    // Constructor.
     using xrt::xclbin::xclbin;
 
   public:
-    rust::String get_xsa_name() const;
-    std::unique_ptr<std::vector<xclbin::kernel>> get_kernels() const;
-    std::unique_ptr<std::vector<xclbin::ip>> get_ips() const;
-    std::array<unsigned char, 16> get_uuid() const;
+    rust::Str xsa_name() const;
+    std::unique_ptr<std::vector<XclbinKernel>> kernels() const;
+    std::unique_ptr<XclbinKernel> kernel(const rust::Str name) const;
+    std::unique_ptr<std::vector<XclbinIp>> ips() const;
+    std::unique_ptr<XclbinIp> ip(const rust::Str name) const;
+    std::array<unsigned char, 16> uuid() const;
   };
 
-  // FFI constructor.
   std::unique_ptr<Xclbin>
   new_xclbin(const rust::Slice<const int8_t> data);
 }
@@ -44,38 +69,37 @@ namespace xrt
 {
   class Device : public xrt::device
   {
-    // Constructor.
     using xrt::device::device;
 
   public:
     // get_info methods.
-    rust::String bdf() const;
+    rust::Str bdf() const;
     std::array<unsigned char, 16> interface_uuid() const;
     uint32_t kdma() const;
     unsigned long max_clock_frequency_mhz() const;
     bool m2m() const;
-    rust::String name() const;
+    rust::Str name() const;
     bool nodma() const;
     bool offline() const;
-    rust::String electrical() const;
-    rust::String thermal() const;
-    rust::String mechanical() const;
-    rust::String memory() const;
-    rust::String platform() const;
-    rust::String pcie_info() const;
-    rust::String host() const;
-    rust::String dynamic_regions() const;
+    // rust::String electrical() const;
+    // rust::String thermal() const;
+    // rust::String mechanical() const;
+    // rust::String memory() const;
+    // rust::String platform() const;
+    // rust::String pcie_info() const;
+    // rust::String host() const;
+    // rust::String dynamic_regions() const;
 
     // Modified member functions.
     std::array<unsigned char, 16> xclbin_uuid() const;
-    std::array<unsigned char, 16> load_xclbin(const Xclbin &xclbin);
+    std::array<unsigned char, 16> load(const Xclbin &xclbin);
   };
 
-  // FFI constructor.
   std::unique_ptr<Device> new_device(unsigned int index);
-
+  std::unique_ptr<Device> new_device_bdf(const rust::Str bdf);
 }
 
+// Kernel
 namespace xrt
 {
   // export nested enum class.
@@ -92,6 +116,22 @@ namespace xrt
   std::unique_ptr<kernel> new_kernel(
       const Device &device,
       std::array<unsigned char, 16> xclbin_id,
-      const rust::String name,
+      const rust::Str name,
       kernel_cu_access_mode mode);
+}
+
+// IP
+namespace xrt
+{
+  // FFI constructor.
+  std::unique_ptr<ip> new_ip(
+      const Device &device,
+      std::array<unsigned char, 16> xclbin_id,
+      const rust::Str name);
+}
+
+// Ini
+namespace xrt
+{
+  void set_ini(rust::Str key, rust::Str value);
 }

--- a/fpga-xrt/src/ffi.h
+++ b/fpga-xrt/src/ffi.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "rust/cxx.h"
+
+#include "fpga-xrt/xrt/src/runtime_src/core/include/xrt/xrt_device.h"
+#include "fpga-xrt/xrt/src/runtime_src/core/include/xrt/xrt_uuid.h"
+
+#include <memory>
+
+namespace xrt {
+
+class Device: public xrt::device {
+  using xrt::device::device;
+public:
+  rust::String name() const;
+  rust::String bdf() const;
+
+  std::array<unsigned char, 16> xclbin_uuid() const;
+};
+
+std::unique_ptr<Device> new_device(unsigned int index);
+
+}

--- a/fpga-xrt/src/ffi.h
+++ b/fpga-xrt/src/ffi.h
@@ -1,8 +1,11 @@
 #pragma once
 #include "rust/cxx.h"
 
-#include "fpga-xrt/xrt/src/runtime_src/core/include/xrt/xrt_device.h"
-#include "fpga-xrt/xrt/src/runtime_src/core/include/xrt/xrt_kernel.h"
+#include "fpga-xrt/xrt/src/runtime_src/core/include/experimental/xrt_device.h"
+#include "fpga-xrt/xrt/src/runtime_src/core/include/experimental/xrt_kernel.h"
+
+// #include "fpga-xrt/xrt/src/runtime_src/core/include/xrt/xrt_device.h"
+// #include "fpga-xrt/xrt/src/runtime_src/core/include/xrt/xrt_kernel.h"
 
 #include "fpga-xrt/xrt/src/runtime_src/core/include/experimental/xrt_xclbin.h"
 

--- a/fpga-xrt/src/ffi.h
+++ b/fpga-xrt/src/ffi.h
@@ -2,21 +2,93 @@
 #include "rust/cxx.h"
 
 #include "fpga-xrt/xrt/src/runtime_src/core/include/xrt/xrt_device.h"
-#include "fpga-xrt/xrt/src/runtime_src/core/include/xrt/xrt_uuid.h"
+#include "fpga-xrt/xrt/src/runtime_src/core/include/xrt/xrt_kernel.h"
 
-#include <memory>
+#include "fpga-xrt/xrt/src/runtime_src/core/include/experimental/xrt_xclbin.h"
 
-namespace xrt {
+// #include <memory>
 
-class Device: public xrt::device {
-  using xrt::device::device;
-public:
-  rust::String name() const;
-  rust::String bdf() const;
+namespace xrt
+{
+  // export nested class.
+  using xclbin_kernel = xclbin::kernel;
 
-  std::array<unsigned char, 16> xclbin_uuid() const;
-};
+  rust::String xclbin_kernel_get_name(const xclbin_kernel &kernel);
 
-std::unique_ptr<Device> new_device(unsigned int index);
+  // export nested class.
+  using xclbin_ip = xclbin::ip;
 
+  rust::String xclbin_ip_get_name(const xclbin_ip &ip);
+
+  class Xclbin : public xrt::xclbin
+  {
+    // Constructor.
+    using xrt::xclbin::xclbin;
+
+  public:
+    rust::String get_xsa_name() const;
+    std::unique_ptr<std::vector<xclbin::kernel>> get_kernels() const;
+    std::unique_ptr<std::vector<xclbin::ip>> get_ips() const;
+    std::array<unsigned char, 16> get_uuid() const;
+  };
+
+  // FFI constructor.
+  std::unique_ptr<Xclbin>
+  new_xclbin(const rust::Slice<const int8_t> data);
+}
+
+namespace xrt
+{
+  class Device : public xrt::device
+  {
+    // Constructor.
+    using xrt::device::device;
+
+  public:
+    // get_info methods.
+    rust::String bdf() const;
+    std::array<unsigned char, 16> interface_uuid() const;
+    uint32_t kdma() const;
+    unsigned long max_clock_frequency_mhz() const;
+    bool m2m() const;
+    rust::String name() const;
+    bool nodma() const;
+    bool offline() const;
+    rust::String electrical() const;
+    rust::String thermal() const;
+    rust::String mechanical() const;
+    rust::String memory() const;
+    rust::String platform() const;
+    rust::String pcie_info() const;
+    rust::String host() const;
+    rust::String dynamic_regions() const;
+
+    // Modified member functions.
+    std::array<unsigned char, 16> xclbin_uuid() const;
+    std::array<unsigned char, 16> load_xclbin(const Xclbin &xclbin);
+  };
+
+  // FFI constructor.
+  std::unique_ptr<Device> new_device(unsigned int index);
+
+}
+
+namespace xrt
+{
+  // export nested enum class.
+  using kernel_cu_access_mode = xrt::kernel::cu_access_mode;
+
+  // class Kernel : public xrt::kernel
+  // {
+  //   using xrt::kernel::kernel;
+
+  // public:
+  // };
+
+  // FFI constructor.
+  std::unique_ptr<kernel> new_kernel(
+      const Device &device,
+      std::array<unsigned char, 16> xclbin_id,
+      const rust::String name,
+      kernel_cu_access_mode mode);
 }

--- a/fpga-xrt/src/ffi.rs
+++ b/fpga-xrt/src/ffi.rs
@@ -1,0 +1,26 @@
+#[cxx::bridge]
+mod ffi {
+    // xrt_device.h
+    #[namespace = "xrt"]
+    unsafe extern "C++" {
+        include!("src/ffi.h");
+
+        // Wrapper class for xrt::device. To handle get_info API.
+        type Device;
+        type uuid;
+
+        // Constructor
+        fn new_device(index: u32) -> Result<UniquePtr<Device>>;
+        
+        // Members
+        fn xclbin_uuid(self: &Device) -> [u8; 16];
+
+        // Custom members
+        fn name(self: &Device) -> String;
+        fn bdf(self: &Device) -> String;
+
+    }
+
+}
+
+pub use ffi::*;

--- a/fpga-xrt/src/ffi.rs
+++ b/fpga-xrt/src/ffi.rs
@@ -1,26 +1,92 @@
 #[cxx::bridge]
 mod ffi {
+
     // xrt_device.h
     #[namespace = "xrt"]
     unsafe extern "C++" {
         include!("src/ffi.h");
 
-        // Wrapper class for xrt::device. To handle get_info API.
         type Device;
-        type uuid;
 
         // Constructor
         fn new_device(index: u32) -> Result<UniquePtr<Device>>;
-        
+
         // Members
         fn xclbin_uuid(self: &Device) -> [u8; 16];
+        fn load_xclbin(self: Pin<&mut Device>, xclbin: &Xclbin) -> [u8; 16];
 
         // Custom members
-        fn name(self: &Device) -> String;
         fn bdf(self: &Device) -> String;
-
+        fn interface_uuid(self: &Device) -> [u8; 16];
+        fn kdma(self: &Device) -> u32;
+        fn max_clock_frequency_mhz(self: &Device) -> u64;
+        fn m2m(self: &Device) -> bool;
+        fn name(self: &Device) -> String;
+        fn nodma(self: &Device) -> bool;
+        fn offline(self: &Device) -> bool;
+        fn electrical(self: &Device) -> String;
+        fn thermal(self: &Device) -> String;
+        fn mechanical(self: &Device) -> String;
+        fn memory(self: &Device) -> String;
+        fn platform(self: &Device) -> String;
+        fn pcie_info(self: &Device) -> String;
+        fn host(self: &Device) -> String;
+        fn dynamic_regions(self: &Device) -> String;
     }
 
+    // xrt_xclbin.h
+    #[namespace = "xrt"]
+    unsafe extern "C++" {
+        include!("src/ffi.h");
+
+        type xclbin_kernel;
+
+        // todo(mb): extend
+        fn xclbin_kernel_get_name(kernel: &xclbin_kernel) -> String;
+
+        type xclbin_ip;
+
+        // todo(mb): extend
+        fn xclbin_ip_get_name(ip: &xclbin_ip) -> String;
+
+        type Xclbin;
+
+        // Constructor
+        fn new_xclbin(bytes: &[i8]) -> Result<UniquePtr<Xclbin>>;
+
+        // Members
+        fn get_kernels(self: &Xclbin) -> UniquePtr<CxxVector<xclbin_kernel>>;
+        fn get_ips(self: &Xclbin) -> UniquePtr<CxxVector<xclbin_ip>>;
+        fn get_xsa_name(self: &Xclbin) -> String;
+        fn get_uuid(self: &Xclbin) -> [u8; 16];
+    }
+
+    #[namespace = "xrt"]
+    enum kernel_cu_access_mode {
+        exclusive,
+        shared,
+        none,
+    }
+
+    // xrt_kernel.h
+    #[namespace = "xrt"]
+    unsafe extern "C++" {
+        include!("src/ffi.h");
+
+        type kernel;
+        type kernel_cu_access_mode;
+
+        // Constructor.
+        fn new_kernel(
+            device: &Device,
+            xclbin_id: [u8; 16],
+            name: String,
+            cu_access_mode: kernel_cu_access_mode,
+        ) -> Result<UniquePtr<kernel>>;
+
+        // Methods.
+        fn read_register(self: &kernel, offset: u32) -> u32;
+    }
 }
 
 pub use ffi::*;

--- a/fpga-xrt/src/ffi.rs
+++ b/fpga-xrt/src/ffi.rs
@@ -7,31 +7,30 @@ mod ffi {
         include!("src/ffi.h");
 
         type Device;
-
-        // Constructor
         fn new_device(index: u32) -> Result<UniquePtr<Device>>;
+        fn new_device_bdf(bdf: &str) -> Result<UniquePtr<Device>>;
 
-        // Members
+        // Modified members
         fn xclbin_uuid(self: &Device) -> [u8; 16];
-        fn load_xclbin(self: Pin<&mut Device>, xclbin: &Xclbin) -> [u8; 16];
+        fn load(self: Pin<&mut Device>, xclbin: &Xclbin) -> [u8; 16];
 
         // Custom members
-        fn bdf(self: &Device) -> String;
+        fn bdf(self: &Device) -> &str;
         fn interface_uuid(self: &Device) -> [u8; 16];
         fn kdma(self: &Device) -> u32;
         fn max_clock_frequency_mhz(self: &Device) -> u64;
         fn m2m(self: &Device) -> bool;
-        fn name(self: &Device) -> String;
+        fn name(self: &Device) -> &str;
         fn nodma(self: &Device) -> bool;
         fn offline(self: &Device) -> bool;
-        fn electrical(self: &Device) -> String;
-        fn thermal(self: &Device) -> String;
-        fn mechanical(self: &Device) -> String;
-        fn memory(self: &Device) -> String;
-        fn platform(self: &Device) -> String;
-        fn pcie_info(self: &Device) -> String;
-        fn host(self: &Device) -> String;
-        fn dynamic_regions(self: &Device) -> String;
+        // fn electrical(self: &Device) -> String;
+        // fn thermal(self: &Device) -> String;
+        // fn mechanical(self: &Device) -> String;
+        // fn memory(self: &Device) -> String;
+        // fn platform(self: &Device) -> String;
+        // fn pcie_info(self: &Device) -> String;
+        // fn host(self: &Device) -> String;
+        // fn dynamic_regions(self: &Device) -> String;
     }
 
     // xrt_xclbin.h
@@ -39,26 +38,32 @@ mod ffi {
     unsafe extern "C++" {
         include!("src/ffi.h");
 
-        type xclbin_kernel;
+        type XclbinArg;
+        fn name(self: &XclbinArg) -> &str;
+        fn mems(self: &XclbinArg) -> UniquePtr<CxxVector<XclbinMem>>;
+        
+        type XclbinIp;
+        fn name(self: &XclbinIp) -> &str;
+        #[rust_name = "num_args"]
+        fn get_num_args(self: &XclbinIp) -> usize;
+        fn args(self: &XclbinIp) -> UniquePtr<CxxVector<XclbinArg>>;
+        fn arg(self: &XclbinIp, index: i32) -> UniquePtr<XclbinArg>;
+        #[rust_name = "base_address"]
+        fn get_base_address(self: &XclbinIp) -> u64;
 
-        // todo(mb): extend
-        fn xclbin_kernel_get_name(kernel: &xclbin_kernel) -> String;
-
-        type xclbin_ip;
-
-        // todo(mb): extend
-        fn xclbin_ip_get_name(ip: &xclbin_ip) -> String;
+        type XclbinKernel;
+        fn name(self: &XclbinKernel) -> &str;
+        
+        type XclbinMem;
 
         type Xclbin;
-
-        // Constructor
         fn new_xclbin(bytes: &[i8]) -> Result<UniquePtr<Xclbin>>;
-
-        // Members
-        fn get_kernels(self: &Xclbin) -> UniquePtr<CxxVector<xclbin_kernel>>;
-        fn get_ips(self: &Xclbin) -> UniquePtr<CxxVector<xclbin_ip>>;
-        fn get_xsa_name(self: &Xclbin) -> String;
-        fn get_uuid(self: &Xclbin) -> [u8; 16];
+        fn kernels(self: &Xclbin) -> UniquePtr<CxxVector<XclbinKernel>>;
+        fn kernel(self: &Xclbin, name: &str) -> UniquePtr<XclbinKernel>;
+        fn ips(self: &Xclbin) -> UniquePtr<CxxVector<XclbinIp>>;
+        fn ip(self: &Xclbin, name: &str) -> UniquePtr<XclbinIp>;
+        fn xsa_name(self: &Xclbin) -> &str;
+        fn uuid(self: &Xclbin) -> [u8; 16];
     }
 
     #[namespace = "xrt"]
@@ -72,20 +77,43 @@ mod ffi {
     #[namespace = "xrt"]
     unsafe extern "C++" {
         include!("src/ffi.h");
-
-        type kernel;
+        
         type kernel_cu_access_mode;
 
-        // Constructor.
+        type kernel;
         fn new_kernel(
             device: &Device,
             xclbin_id: [u8; 16],
-            name: String,
+            name: &str,
             cu_access_mode: kernel_cu_access_mode,
         ) -> Result<UniquePtr<kernel>>;
-
-        // Methods.
+        fn group_id(self: &kernel, argno: i32) -> i32;
+        fn offset(self: &kernel, argno: i32) -> u32;
         fn read_register(self: &kernel, offset: u32) -> u32;
+        fn write_register(self: Pin<&mut kernel>, offset: u32, data: u32) -> Result<()>;
+    }
+
+    // xrt_ip.h
+    #[namespace = "xrt"]
+    unsafe extern "C++" {
+        include!("src/ffi.h");
+        
+        type ip;
+        fn new_ip(
+            device: &Device,
+            xclbin_id: [u8; 16],
+            name: &str
+        ) -> Result<UniquePtr<ip>>;
+        fn read_register(self: &ip, offset: u32) -> u32;
+        fn write_register(self: Pin<&mut ip>, offset: u32, data: u32) -> Result<()>;
+    }
+
+    // xrt_ini.h
+    #[namespace = "xrt"]
+    unsafe extern "C++" {
+        include!("src/ffi.h");
+
+        fn set_ini(key: &str, value: &str) -> Result<()>;
     }
 }
 

--- a/fpga-xrt/src/info.rs
+++ b/fpga-xrt/src/info.rs
@@ -1,0 +1,296 @@
+use crate::Xrt;
+use serde::Deserialize;
+use std::str::FromStr;
+use uuid::Uuid;
+
+#[derive(Debug, Deserialize)]
+pub struct Electrical {
+    #[serde(deserialize_with = "parse")]
+    pub power_consumption_max_watts: f32,
+    #[serde(deserialize_with = "parse")]
+    pub power_consumption_warning: bool,
+    #[serde(deserialize_with = "parse")]
+    pub power_consumption_watts: f32,
+    pub power_rails: Vec<Power>,
+}
+
+fn parse<'de, T: FromStr, D: serde::de::Deserializer<'de>>(deserializer: D) -> Result<T, D::Error>
+where
+    <T as FromStr>::Err: std::fmt::Display,
+{
+    Ok(match serde_json::Value::deserialize(deserializer)? {
+        serde_json::Value::String(s) => s.parse::<T>().map_err(serde::de::Error::custom)?,
+        _ => return Err(serde::de::Error::custom("unexpected value")),
+    })
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Power {
+    pub id: String,
+    pub description: String,
+    pub current: Current,
+    pub voltage: Voltage,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Current {
+    #[serde(deserialize_with = "parse")]
+    pub amps: f32,
+    #[serde(deserialize_with = "parse")]
+    pub is_present: bool,
+    error_msg: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Voltage {
+    #[serde(deserialize_with = "parse")]
+    pub volts: f32,
+    #[serde(deserialize_with = "parse")]
+    pub is_present: bool,
+    pub error_msg: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Thermals {
+    pub thermals: Vec<Thermal>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Thermal {
+    pub location_id: String,
+    pub description: String,
+    #[serde(rename(deserialize = "temp_C"), deserialize_with = "parse")]
+    pub temp_c: u8,
+    #[serde(deserialize_with = "parse")]
+    pub is_present: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Mechanical {
+    pub fans: Vec<Fan>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Fan {
+    pub location_id: String,
+    pub description: String,
+    #[serde(deserialize_with = "parse")]
+    pub speed_rpm: u16,
+    #[serde(
+        rename(deserialize = "critical_trigger_temp_C"),
+        deserialize_with = "parse"
+    )]
+    pub critical_trigger_temp_c: u8,
+    #[serde(deserialize_with = "parse")]
+    pub is_present: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Memory {
+    pub board: Option<Board>,
+    pub error_msg: Option<String>,
+}
+#[derive(Debug, Deserialize)]
+pub struct Board {
+    pub direct_memory_accesses: DirectMemoryAccesses,
+    pub memory: InnerMemory,
+}
+#[derive(Debug, Deserialize)]
+pub struct DirectMemoryAccesses {
+    pub metrics: Vec<Metric>,
+    #[serde(rename(deserialize = "type"))]
+    pub ty: String,
+}
+#[derive(Debug, Deserialize)]
+pub struct Metric {
+    #[serde(deserialize_with = "parse")]
+    pub channel_id: u8,
+    pub card_to_host_bytes: String, // todo
+    pub host_to_card_bytes: String, // todo
+}
+#[derive(Debug, Deserialize)]
+pub struct InnerMemory {
+    pub data_streams: Vec<DataStream>,
+    pub memories: Vec<Mem>,
+}
+#[derive(Debug, Deserialize)]
+pub struct Mem {
+    pub base_address: String, // todo
+    #[serde(deserialize_with = "parse")]
+    pub enabled: bool,
+    pub error_msg: Option<String>,
+    pub extended_info: ExtendedInfo,
+    pub range_bytes: String, // todo
+    pub tag: String,
+    #[serde(rename(deserialize = "type"))]
+    pub ty: String,
+}
+#[derive(Debug, Deserialize)]
+pub struct ExtendedInfo {
+    pub usage: Usage,
+}
+#[derive(Debug, Deserialize)]
+pub struct Usage {
+    #[serde(deserialize_with = "parse")]
+    pub allocated_bytes: u64,
+    #[serde(deserialize_with = "parse")]
+    pub buffer_objects_count: u64,
+}
+#[derive(Debug, Deserialize)]
+pub struct DataStream {
+    pub tag: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Platform {
+    pub controller: Controller,
+    pub macs: Vec<Mac>,
+    pub off_chip_board_info: OffChipBoardInfo,
+    pub static_region: StaticRegion,
+    pub status: Status,
+}
+
+#[derive(Deserialize)]
+struct Wrapper<T> {
+    #[serde(rename(deserialize = ""))]
+    inner: T,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Controller {
+    pub card_mgmt_controller: CardMgmtController,
+    pub satellite_controller: SatelliteController,
+}
+#[derive(Debug, Deserialize)]
+pub struct CardMgmtController {
+    pub oem_id: String,
+    pub serial_number: String,
+    pub version: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SatelliteController {
+    pub expected_version: String,
+    pub version: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Mac {
+    pub address: String, // todo [u8; 6]
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OffChipBoardInfo {
+    #[serde(deserialize_with = "parse")]
+    pub ddr_count: u8,
+    #[serde(deserialize_with = "parse")]
+    pub ddr_size_bytes: u64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StaticRegion {
+    pub fpga_name: String,
+    pub interface_uuid: String,
+    pub jtag_idcode: String,
+    pub vbnv: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Status {
+    #[serde(deserialize_with = "parse")]
+    pub mig_calibrated: bool,
+    pub p2p_status: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PCIeInfo {
+    pub cpu_affinity: String,
+    pub device: String,
+    #[serde(deserialize_with = "parse")]
+    pub dma_thread_count: u8,
+    #[serde(deserialize_with = "parse")]
+    pub express_lane_width_count: u8,
+    #[serde(deserialize_with = "parse")]
+    pub link_speed_gbit_sec: u16,
+    #[serde(deserialize_with = "parse")]
+    pub max_shared_host_mem_aperture_bytes: u64,
+    pub sub_device: String,
+    pub sub_vendor: String,
+    pub vendor: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Host {
+    pub branch: String,
+    pub build_date: String,
+    pub hash: String,
+    pub version: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DynamicRegions {
+    pub xclbin_uuid: Uuid,
+}
+
+impl Xrt {
+    pub fn bdf(&self) -> String {
+        self.device.bdf()
+    }
+    pub fn interface_uuid(&self) -> Uuid {
+        Uuid::from_bytes(self.device.interface_uuid())
+    }
+    pub fn kdma(&self) -> u32 {
+        self.device.kdma()
+    }
+    pub fn max_clock_frequency_mhz(&self) -> u64 {
+        self.device.max_clock_frequency_mhz()
+    }
+    pub fn m2m(&self) -> bool {
+        self.device.m2m()
+    }
+    pub fn name(&self) -> String {
+        self.device.name()
+    }
+    pub fn nodma(&self) -> bool {
+        self.device.nodma()
+    }
+    pub fn offline(&self) -> bool {
+        self.device.offline()
+    }
+    pub fn electrical(&self) -> Electrical {
+        let mut electrical: Electrical = serde_json::from_str(&self.device.electrical()).unwrap();
+        electrical.power_rails = electrical
+            .power_rails
+            .into_iter()
+            .filter(|power| power.current.is_present || power.voltage.is_present)
+            .collect();
+        electrical
+    }
+    pub fn thermal(&self) -> Vec<Thermal> {
+        let thermals: Thermals = serde_json::from_str(&self.device.thermal()).unwrap();
+        thermals
+            .thermals
+            .into_iter()
+            .filter(|thermal| thermal.is_present)
+            .collect()
+    }
+    pub fn mechanical(&self) -> Mechanical {
+        serde_json::from_str(&self.device.mechanical()).unwrap()
+    }
+    pub fn memory(&self) -> Memory {
+        serde_json::from_str(&self.device.memory()).unwrap()
+    }
+    pub fn platform(&self) -> Platform {
+        let wrapper: Wrapper<Platform> = serde_json::from_str(&self.device.platform()).unwrap();
+        wrapper.inner
+    }
+    pub fn pcie_info(&self) -> PCIeInfo {
+        serde_json::from_str(&self.device.pcie_info()).unwrap()
+    }
+    pub fn host(&self) -> Host {
+        serde_json::from_str(&self.device.host()).unwrap()
+    }
+    pub fn dynamic_regions(&self) -> DynamicRegions {
+        serde_json::from_str(&self.device.dynamic_regions()).unwrap()
+    }
+}

--- a/fpga-xrt/src/info.rs
+++ b/fpga-xrt/src/info.rs
@@ -233,7 +233,7 @@ pub struct DynamicRegions {
 }
 
 impl Xrt {
-    pub fn bdf(&self) -> String {
+    pub fn bdf(&self) -> &str {
         self.device.bdf()
     }
     pub fn interface_uuid(&self) -> Uuid {
@@ -248,7 +248,7 @@ impl Xrt {
     pub fn m2m(&self) -> bool {
         self.device.m2m()
     }
-    pub fn name(&self) -> String {
+    pub fn name(&self) -> &str {
         self.device.name()
     }
     pub fn nodma(&self) -> bool {
@@ -257,40 +257,40 @@ impl Xrt {
     pub fn offline(&self) -> bool {
         self.device.offline()
     }
-    pub fn electrical(&self) -> Electrical {
-        let mut electrical: Electrical = serde_json::from_str(&self.device.electrical()).unwrap();
-        electrical.power_rails = electrical
-            .power_rails
-            .into_iter()
-            .filter(|power| power.current.is_present || power.voltage.is_present)
-            .collect();
-        electrical
-    }
-    pub fn thermal(&self) -> Vec<Thermal> {
-        let thermals: Thermals = serde_json::from_str(&self.device.thermal()).unwrap();
-        thermals
-            .thermals
-            .into_iter()
-            .filter(|thermal| thermal.is_present)
-            .collect()
-    }
-    pub fn mechanical(&self) -> Mechanical {
-        serde_json::from_str(&self.device.mechanical()).unwrap()
-    }
-    pub fn memory(&self) -> Memory {
-        serde_json::from_str(&self.device.memory()).unwrap()
-    }
-    pub fn platform(&self) -> Platform {
-        let wrapper: Wrapper<Platform> = serde_json::from_str(&self.device.platform()).unwrap();
-        wrapper.inner
-    }
-    pub fn pcie_info(&self) -> PCIeInfo {
-        serde_json::from_str(&self.device.pcie_info()).unwrap()
-    }
-    pub fn host(&self) -> Host {
-        serde_json::from_str(&self.device.host()).unwrap()
-    }
-    pub fn dynamic_regions(&self) -> DynamicRegions {
-        serde_json::from_str(&self.device.dynamic_regions()).unwrap()
-    }
+    // pub fn electrical(&self) -> Electrical {
+    //     let mut electrical: Electrical = serde_json::from_str(&self.device.electrical()).unwrap();
+    //     electrical.power_rails = electrical
+    //         .power_rails
+    //         .into_iter()
+    //         .filter(|power| power.current.is_present || power.voltage.is_present)
+    //         .collect();
+    //     electrical
+    // }
+    // pub fn thermal(&self) -> Vec<Thermal> {
+    //     let thermals: Thermals = serde_json::from_str(&self.device.thermal()).unwrap();
+    //     thermals
+    //         .thermals
+    //         .into_iter()
+    //         .filter(|thermal| thermal.is_present)
+    //         .collect()
+    // }
+    // pub fn mechanical(&self) -> Mechanical {
+    //     serde_json::from_str(&self.device.mechanical()).unwrap()
+    // }
+    // pub fn memory(&self) -> Memory {
+    //     serde_json::from_str(&self.device.memory()).unwrap()
+    // }
+    // pub fn platform(&self) -> Platform {
+    //     let wrapper: Wrapper<Platform> = serde_json::from_str(&self.device.platform()).unwrap();
+    //     wrapper.inner
+    // }
+    // pub fn pcie_info(&self) -> PCIeInfo {
+    //     serde_json::from_str(&self.device.pcie_info()).unwrap()
+    // }
+    // pub fn host(&self) -> Host {
+    //     serde_json::from_str(&self.device.host()).unwrap()
+    // }
+    // pub fn dynamic_regions(&self) -> DynamicRegions {
+    //     serde_json::from_str(&self.device.dynamic_regions()).unwrap()
+    // }
 }

--- a/fpga-xrt/src/ip.rs
+++ b/fpga-xrt/src/ip.rs
@@ -1,0 +1,6 @@
+use crate::ffi;
+use cxx::UniquePtr;
+
+pub struct Ip {
+    pub(crate) ip: UniquePtr<ffi::ip>,
+}

--- a/fpga-xrt/src/kernel.rs
+++ b/fpga-xrt/src/kernel.rs
@@ -1,0 +1,6 @@
+use crate::ffi;
+use cxx::UniquePtr;
+
+pub struct Kernel {
+    pub(crate) kernel: UniquePtr<ffi::kernel>,
+}

--- a/fpga-xrt/src/lib.rs
+++ b/fpga-xrt/src/lib.rs
@@ -1,211 +1,32 @@
-use fpga_core::Platform;
-use log::{error, info};
-use std::{
-    ffi::{c_void, CStr, CString},
-    io::Error,
-    ops::Not,
-    os::raw::c_int,
-    ptr::{self, NonNull},
-    sync::Once,
-};
+use cxx::{Exception, UniquePtr};
 use uuid::Uuid;
 
-// todo(mb): visibility
-pub mod bindings;
-use bindings::{
-    xclDeviceHandle, xclDeviceInfo2, xclGetDeviceInfo2, xclProbe, xrtDeviceClose,
-    xrtDeviceGetXclbinUUID, xrtDeviceHandle, xrtDeviceOpen, xrtDeviceOpenByBDF,
-    xrtDeviceToXclDevice, xrtIniStringSet,
-};
+mod ffi;
+// pub mod bindings;
 
-pub type Result<T> = std::result::Result<T, Error>;
+type Result<T> = std::result::Result<T, Exception>;
 
-/// One-time global initialization for Xrt.
-static INIT: Once = Once::new();
-
-/// Number of XRT devices in the system. Populated during initialization.
-static mut XRT_DEVICES: Result<usize> = Ok(0); // this should default to Err(Error::from_raw_os_error(libc::ENODEV));
-
-// Key-value pair to disable runtime logging by XRT via xrt.ini.
-static RUNTIME_LOG_KEY: &[u8] = b"Runtime.runtime_log\0";
-static RUNTIME_LOG_VALUE: &[u8] = b"null\0";
-
-#[derive(Debug)]
 pub struct Xrt {
-    /// Handle to XRT device. Always non-null.
-    handle: NonNull<c_void>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum Configuration {
-    FirstDevice,
-    DeviceIndex(usize),
-    BusDeviceFunction(String),
-}
-
-impl Platform for Xrt {
-    const NAME: &'static str = "XRT";
-
-    type Configuration = Configuration;
-    type Error = Error;
-
-    fn from_configuration(configuration: Self::Configuration) -> Result<Self> {
-        match configuration {
-            Configuration::FirstDevice => Self::new(),
-            Configuration::DeviceIndex(device_index) => Self::from_device_index(device_index),
-            Configuration::BusDeviceFunction(ref bdf) => Self::from_bus_device_function(bdf),
-        }
-    }
-}
-
-impl Drop for Xrt {
-    fn drop(&mut self) {
-        // Safety
-        // - Handle is always non-null
-        let result = unsafe { xrtDeviceClose(self.handle.as_ptr()) };
-
-        // Drop should not panic so we ignore failed closing of the device.
-        // Instead an error message is written.
-        if result != 0 {
-            error!("Failed to close xrt device");
-        }
-    }
-}
-
-fn init() {
-    INIT.call_once(|| {
-        if unsafe {
-            // Disable runtime logging by XRT
-            xrtIniStringSet(
-                CStr::from_bytes_with_nul_unchecked(RUNTIME_LOG_KEY).as_ptr(),
-                CStr::from_bytes_with_nul_unchecked(RUNTIME_LOG_VALUE).as_ptr(),
-            )
-        } != 0
-        {
-            panic!("Failed to update xrt.ini configuration to disable logging")
-        }
-        // Get number of XRT devices.
-        unsafe {
-            let n = xclProbe();
-            if n != 0 {
-                XRT_DEVICES = Ok(n as usize);
-            }
-        }
-    });
-}
-
-fn errno() -> Error {
-    Error::from_raw_os_error({
-        let errno = unsafe { libc::__errno_location() };
-        if errno.is_null() {
-            // Pointer returned by __errno_location is null.
-            libc::EFAULT
-        } else {
-            // Safety
-            // - Checked for null pointer above.
-            unsafe { ptr::read(errno) }
-        }
-    })
-}
-
-fn check(result: c_int) -> Result<()> {
-    (result == 0).then(|| ()).ok_or_else(errno)
-}
-
-/// Checks if given handle is non-null. Returns None when handle is null.
-fn check_device_handle(handle: xrtDeviceHandle) -> Result<Xrt> {
-    handle
-        .is_null()
-        .not()
-        .then(||
-            // Safety:
-            // - Checked that pointer is non-null.
-            Xrt {
-                handle: unsafe { NonNull::new_unchecked(handle) }
-            })
-        .ok_or_else(|| Error::from_raw_os_error(libc::ENODEV))
+  device: UniquePtr<ffi::Device>,
 }
 
 impl Xrt {
-    /// Returns the number of XRT devices in the system.
-    pub fn num_devices() -> usize {
-        init();
-        // Safety
-        // - Value set by init above.
-        unsafe { XRT_DEVICES.unwrap_or(0) }
-    }
+  pub fn new() -> Result<Self> {
+      Self::from_device_index(0)
+  }
 
-    pub fn new() -> Result<Self> {
-        init();
-        // Init checks that there is at least one device.
-        Self::from_device_index(0)
-    }
+  pub fn from_device_index(index: usize) -> Result<Self> {
+    Ok(Self {
+        device: ffi::new_device(index as u32)?
+    })
+  }
 
-    pub fn from_device_index(device_index: usize) -> Result<Self> {
-        #[cold]
-        #[inline(never)]
-        fn assert_failed(device_index: usize) -> ! {
-            panic!(
-                "device_index (is {}) should be < number of XRT devices (is {})",
-                device_index,
-                Xrt::num_devices()
-            );
-        }
+  pub fn name(&self) -> String {
+    self.device.name()
+  }
 
-        // Safety
-        // - Value set by init above.
-        if device_index >= Self::num_devices() {
-            assert_failed(device_index);
-        }
+  pub fn uuid(&self) -> Uuid {
+    Uuid::from_bytes(self.device.xclbin_uuid())
+  }
 
-        check_device_handle(unsafe { xrtDeviceOpen(device_index as u32) })
-    }
-
-    pub fn from_bus_device_function<T>(bus_device_function: T) -> Result<Self>
-    where
-        T: AsRef<str>,
-    {
-        init();
-        let bdf = CString::new(bus_device_function.as_ref())?;
-        check_device_handle(unsafe { xrtDeviceOpenByBDF(bdf.as_ptr()) })
-    }
-
-    fn xcl_handle(&self) -> Result<xclDeviceHandle> {
-        let handle = unsafe { xrtDeviceToXclDevice(self.handle.as_ptr()) };
-        handle.is_null().not().then(|| handle).ok_or_else(errno)
-    }
-
-    pub fn xclbin_uuid(&self) -> Option<Uuid> {
-        // Initialize some bytes on the stack to store the Uuid.
-        let mut uuid_bytes: uuid::Bytes = [0; 16];
-
-        // Safety
-        // - Handle is always non-null.
-        // - Uuid bytes initialized above.
-        check(unsafe { xrtDeviceGetXclbinUUID(self.handle.as_ptr(), uuid_bytes.as_mut_ptr()) })
-            .ok()?;
-
-        // 0 indicates no xclbin is loaded on the device.
-        (Uuid::from_bytes(uuid_bytes) == Uuid::nil())
-            .not()
-            .then(|| Uuid::from_bytes(uuid_bytes))
-    }
-
-    pub fn info(&self) -> Result<()> {
-        let mut info = xclDeviceInfo2::default();
-        check(unsafe { xclGetDeviceInfo2(self.xcl_handle()?, &mut info) })?;
-        info!("{:#?}", &info);
-        Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // todo(mb): cfg_if based on num of devices
-    #[test]
-    fn device() {
-        let device = Xrt::from_configuration(Configuration::FirstDevice);
-    }
 }

--- a/fpga-xrt/src/lib.rs
+++ b/fpga-xrt/src/lib.rs
@@ -60,7 +60,8 @@ impl Program for Xrt {
     type Source = Xclbin;
     type Output = Uuid;
 
-    fn program(&mut self, source: Self::Source) -> Result<Self::Output> {
+    fn program(&mut self, source: &Self::Source) -> Result<Self::Output> {
+        // todo(mb): validate that the source targets this device
         Ok(Uuid::from_bytes(
             self.device.pin_mut().load_xclbin(&source.xclbin),
         ))

--- a/fpga-xrt/src/lib.rs
+++ b/fpga-xrt/src/lib.rs
@@ -1,32 +1,123 @@
+use std::pin::Pin;
+
 use cxx::{Exception, UniquePtr};
+use fpga_core::{Platform, PlatformType, Power, Program, Thermal};
 use uuid::Uuid;
 
-mod ffi;
-// pub mod bindings;
+pub(crate) mod ffi;
+
+mod info;
+pub use info::*;
+
+mod xclbin;
+pub use xclbin::*;
+
+mod kernel;
+pub use kernel::*;
 
 type Result<T> = std::result::Result<T, Exception>;
 
 pub struct Xrt {
-  device: UniquePtr<ffi::Device>,
+    device: UniquePtr<ffi::Device>,
 }
 
 impl Xrt {
-  pub fn new() -> Result<Self> {
-      Self::from_device_index(0)
-  }
+    pub fn kernel(&self, uuid: Uuid, name: &str) -> Kernel {
+        Kernel {
+            kernel: ffi::new_kernel(
+                &self.device,
+                *uuid.as_bytes(),
+                name.to_string(),
+                ffi::kernel_cu_access_mode::exclusive,
+            )
+            .unwrap(),
+        }
+    }
+}
 
-  pub fn from_device_index(index: usize) -> Result<Self> {
-    Ok(Self {
-        device: ffi::new_device(index as u32)?
-    })
-  }
+pub enum Configuration {
+    DeviceIndex(usize),
+    Bdf(String),
+}
 
-  pub fn name(&self) -> String {
-    self.device.name()
-  }
+impl Platform for Xrt {
+    type Configuration = Configuration;
+    type Error = Exception;
 
-  pub fn uuid(&self) -> Uuid {
-    Uuid::from_bytes(self.device.xclbin_uuid())
-  }
+    fn from_configuration(configuration: Self::Configuration) -> Result<Self> {
+        match configuration {
+            Configuration::DeviceIndex(index) => Self::from_device_index(index),
+            Configuration::Bdf(_) => todo!(),
+        }
+    }
 
+    fn platform(&self) -> PlatformType {
+        PlatformType::XRT
+    }
+}
+
+impl Program for Xrt {
+    type Source = Xclbin;
+    type Output = Uuid;
+
+    fn program(&mut self, source: Self::Source) -> Result<Self::Output> {
+        Ok(Uuid::from_bytes(
+            self.device.pin_mut().load_xclbin(&source.xclbin),
+        ))
+    }
+}
+
+impl Power for Xrt {
+    fn power(&self) -> f32 {
+        self.electrical().power_consumption_watts
+    }
+}
+
+impl Thermal for Xrt {
+    fn temperature(&self) -> f32 {
+        self.thermal()
+            .into_iter()
+            .find(|thermal| thermal.location_id == "fpga0")
+            .map(|thermal| thermal.temp_c)
+            .unwrap_or_default() as f32
+    }
+}
+
+impl std::fmt::Debug for Xrt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Xrt")
+            .field("bdf", &self.bdf())
+            .field("interface_uuid", &self.interface_uuid())
+            .field("kdma", &self.kdma())
+            .field("max_clock_frequency_mhz", &self.max_clock_frequency_mhz())
+            .field("m2m", &self.m2m())
+            .field("name", &self.name())
+            .field("nodma", &self.nodma())
+            .field("offline", &self.offline())
+            .field("electrical", &self.electrical())
+            .field("thermal", &self.thermal())
+            .field("mechanical", &self.mechanical())
+            .field("memory", &self.memory())
+            .field("platform", &self.platform())
+            .field("pcie_info", &self.pcie_info())
+            .field("host", &self.host())
+            .field("dynamic_regions", &self.dynamic_regions())
+            .finish()
+    }
+}
+
+impl Xrt {
+    pub fn new() -> Result<Self> {
+        Self::from_device_index(0)
+    }
+
+    pub fn from_device_index(index: usize) -> Result<Self> {
+        Ok(Self {
+            device: ffi::new_device(index as u32)?,
+        })
+    }
+
+    pub fn uuid(&self) -> Uuid {
+        Uuid::from_bytes(self.device.xclbin_uuid())
+    }
 }

--- a/fpga-xrt/src/main.rs
+++ b/fpga-xrt/src/main.rs
@@ -1,0 +1,11 @@
+use fpga_xrt::Xrt;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // let device = Xrt::new()?;
+    for i in 0..3 {
+        let device = Xrt::from_device_index(i)?;
+        println!("{}", device.name());
+        println!("{}", device.uuid());
+    }
+    Ok(())
+}

--- a/fpga-xrt/src/xclbin.rs
+++ b/fpga-xrt/src/xclbin.rs
@@ -1,0 +1,60 @@
+use crate::ffi::{self, new_xclbin, xclbin_ip_get_name, xclbin_kernel_get_name};
+use cxx::UniquePtr;
+use std::{fmt::Debug, fs, path::Path};
+use uuid::Uuid;
+
+pub struct Xclbin {
+    pub(crate) xclbin: UniquePtr<ffi::Xclbin>,
+}
+
+impl Debug for Xclbin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Xclbin")
+            .field("xsa_name", &self.get_xsa_name())
+            .field("uuid", &self.get_uuid())
+            .finish()
+    }
+}
+
+impl Xclbin {
+    pub fn get_xsa_name(&self) -> String {
+        self.xclbin.get_xsa_name()
+    }
+
+    pub fn get_kernels(&self) {
+        self.xclbin.get_kernels().iter().for_each(|kernel| {
+            println!("{}", xclbin_kernel_get_name(&kernel));
+        });
+    }
+
+    pub fn get_ips(&self) {
+        self.xclbin.get_ips().iter().for_each(|ip| {
+            println!("{}", xclbin_ip_get_name(&ip));
+        });
+    }
+
+    pub fn get_uuid(&self) -> Uuid {
+        Uuid::from_bytes(self.xclbin.get_uuid())
+    }
+}
+
+impl Xclbin {
+    pub fn from_file<T: AsRef<Path>>(path: T) -> Result<Self, std::io::Error> {
+        // Attempt to read the file.
+        let data = fs::read(path)?;
+
+        // Cast to i8, because that is what the C++ api expects.
+        // Prevent destructor.
+        let mut data = std::mem::ManuallyDrop::new(data);
+        // Cast.
+        // todo(mb): cast in c++ (don't know how without a copy)
+        let input = unsafe {
+            Vec::from_raw_parts(data.as_mut_ptr() as *mut i8, data.len(), data.capacity())
+        };
+        Ok(Self {
+            xclbin: new_xclbin(&input).map_err(|exception| {
+                std::io::Error::new(std::io::ErrorKind::InvalidData, exception.what())
+            })?,
+        })
+    }
+}

--- a/fpga-xrt/src/xclbin.rs
+++ b/fpga-xrt/src/xclbin.rs
@@ -1,4 +1,4 @@
-use crate::ffi::{self, new_xclbin, xclbin_ip_get_name, xclbin_kernel_get_name};
+use crate::ffi::{self, new_xclbin};
 use cxx::UniquePtr;
 use std::{fmt::Debug, fs, path::Path};
 use uuid::Uuid;
@@ -10,31 +10,33 @@ pub struct Xclbin {
 impl Debug for Xclbin {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Xclbin")
-            .field("xsa_name", &self.get_xsa_name())
-            .field("uuid", &self.get_uuid())
+            .field("xsa_name", &self.xsa_name())
+            .field("uuid", &self.uuid())
             .finish()
     }
 }
 
 impl Xclbin {
-    pub fn get_xsa_name(&self) -> String {
-        self.xclbin.get_xsa_name()
+    pub fn xsa_name(&self) -> &str {
+        self.xclbin.xsa_name()
     }
 
-    pub fn get_kernels(&self) {
-        self.xclbin.get_kernels().iter().for_each(|kernel| {
-            println!("{}", xclbin_kernel_get_name(&kernel));
-        });
+    pub fn kernels(&self) {
+        dbg!(self.xclbin.kernels().len());
+        // self.xclbin.kernels().iter().for_each(|kernel| {
+        //     println!("{}", kernel.name());
+        // });
     }
 
-    pub fn get_ips(&self) {
-        self.xclbin.get_ips().iter().for_each(|ip| {
-            println!("{}", xclbin_ip_get_name(&ip));
-        });
+    pub fn ips(&self) {
+        dbg!(self.xclbin.ips().len());
+        // .iter().for_each(|ip| {
+        //     println!("{}", ip.name());
+        // });
     }
 
-    pub fn get_uuid(&self) -> Uuid {
-        Uuid::from_bytes(self.xclbin.get_uuid())
+    pub fn uuid(&self) -> Uuid {
+        Uuid::from_bytes(self.xclbin.uuid())
     }
 }
 

--- a/fpga/Cargo.toml
+++ b/fpga/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Matthijs Brobbel <m1brobbel@gmail.com>"]
 edition = "2018"
 
 [features]
-default = []
+default = ["xrt"]
 opae = ["fpga-opae"]
 xrt = ["fpga-xrt"]
 

--- a/fpga/src/lib.rs
+++ b/fpga/src/lib.rs
@@ -5,3 +5,17 @@ pub use fpga_xrt as xrt;
 
 #[cfg(feature = "opae")]
 pub use fpga_opae as opae;
+
+pub fn discover() -> Option<Box<dyn Platform>> {
+    #[cfg(feature = "xrt")]
+    if let Some(platform) = xrt::Xrt::new().ok() {
+        return Some(Box::new(platform) as Box<dyn Platform>);
+    }
+
+    #[cfg(feature = "opae")]
+    if let Some(platform) = opae::Opae::new().ok() {
+        return Some(Box::new(platform) as Box<dyn Platform>);
+    }
+
+    None
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
Moving from unsafe C bindings to safe C++ bindings with [cxx](https://cxx.rs).

- The native XRT [C-API](https://xilinx.github.io/XRT/2021.1/html/xrt_native.main.html#id1) is less complete than the [C++-API](https://xilinx.github.io/XRT/2021.1/html/xrt_native.main.html)
- Using the C-API requires usage of raw pointers in Rust, which results in lots of unsafe code

The build step links XRT statically. It is still required to have the correct driver version installed, but I'm hoping that at some point Xilinx makes future driver versions backwards compatible.

The build script requires
- an internet connection (to download boost) - maybe I should vendor this instead
- CMake > 3
- C++14 compiler

Tasks
- [ ] Complete bindings - test with fletchers
- [ ] Documentation
- [ ] Check memory leaks